### PR TITLE
[merged] build: Fix Rust version to actually be conditional, and off by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,10 @@ LIBS=$BUILDDEP_LIBGIT_GLIB_LIBS
 AC_CHECK_FUNCS(git_libgit2_init)
 LIBS=$save_LIBS
 
+AC_ARG_ENABLE(rust,
+              [AS_HELP_STRING([--enable-rust],
+                              [Compile Rust version [default=no]])],,
+              enable_rust=no)
 AS_IF([test "$enable_rust" != no], [
   AC_PATH_PROG([CARGO], [cargo])
   AS_IF([test -z "$CARGO"], [

--- a/rust/Makefile-inc.am
+++ b/rust/Makefile-inc.am
@@ -1,4 +1,6 @@
+if ENABLE_RUST
 bin_PROGRAMS += git-rustevtag
 
 git-rustevtag: rust/src/main.rs rust/Cargo.toml
 	(cd rust && cargo build) && cp rust/target/debug/git-rustevtag .
+endif


### PR DESCRIPTION
Until we land the git2-rs changes (and have the cargo entry reference
code outside of my homedir) there's not much point to enabling it by
default.

Closes #14