### PR TITLE
Fix/autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -7,8 +7,8 @@ test -n "$srcdir" || srcdir=.
 olddir="$(pwd)"
 cd "$srcdir"
 
-AUTORECONF=`which autoreconf`
-if test -z $AUTORECONF; then
+if ! command -v autoreconf >/dev/null 2>&1
+then
         echo "*** No autoreconf found, please intall it ***"
         exit 1
 fi

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 set -e
 
-test -n "$srcdir" || srcdir=`dirname "$0"`
+test -n "$srcdir" || srcdir="$(dirname "$0")"
 test -n "$srcdir" || srcdir=.
 
-olddir=`pwd`
-cd $srcdir
+olddir="$(pwd)"
+cd "$srcdir"
 
 AUTORECONF=`which autoreconf`
 if test -z $AUTORECONF; then
@@ -17,5 +17,5 @@ mkdir -p m4
 
 autoreconf --force --install --verbose
 
-cd $olddir
+cd "$olddir"
 test -n "$NOCONFIGURE" || "$srcdir/configure" "$@"


### PR DESCRIPTION
`git-evtag` and `git-evtag-compute-py` work on Debian Jessie :+1:

For reference, these are the packages I needed to install on Debian Jessie to build `git-evtag`.

    build-essential
    dh-autoreconf
    libgit2-dev
    pkg-config
    libglib2.0-dev
    xsltproc