### PR TITLE
rust: rustc-serialize → hex

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,8 +6,8 @@ authors = ["Colin Walters <walters@verbum.org>"]
 [dependencies]
 clap = "2"
 git2 = "0.6.11"
+hex = "0.3"
 openssl = "0.9"
-rustc-serialize = "0.3"
 
 [[bin]]
 name = "git-rustevtag"

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -9,8 +9,8 @@
 #[macro_use]
 extern crate clap;
 extern crate git2;
+extern crate hex;
 extern crate openssl;
-extern crate rustc_serialize;
 
 use std::error::Error as StdError;
 use std::io::Write;
@@ -18,7 +18,6 @@ use std::process::Command;
 
 use git2::{Commit, Error, Object, ObjectType, Oid, Repository, Submodule, Tree};
 use openssl::hash::{DigestBytes, Hasher};
-use rustc_serialize::hex::ToHex;
 
 const EVTAG_SHA512: &'static str = "Git-EVTag-v0-SHA512:";
 
@@ -128,7 +127,7 @@ fn run(args: &Args) -> Result<(), Error> {
         }
     }
 
-    let expected_checksum = evtag.compute(specified_oid)?.to_hex();
+    let expected_checksum = hex::encode(evtag.compute(specified_oid)?);
 
     let message = match tag.message() {
         Some(message) => message,


### PR DESCRIPTION
rustc-serialize is deprecated for long time and we don't really need it,
we can replace one line with simple hex crate.

Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>