### PR TITLE
Fix nested submodules

### DIFF
--- a/src/git-evtag-compute-py
+++ b/src/git-evtag-compute-py
@@ -76,7 +76,7 @@ def checksum_object(repo, objid):
         raise subprocess.CalledProcessError(p.returncode, 'git cat-file')
     return treeobjid
 
-def checksum_tree(repo, objid):
+def checksum_tree(repo, path, objid):
     checksum_object(repo, objid)
     p = subprocess.Popen(['git', 'ls-tree', objid],
                          stdin=DEVNULL,
@@ -89,9 +89,9 @@ def checksum_tree(repo, objid):
         if otype == 'blob':
             checksum_object(repo, subid)
         elif otype == 'tree':
-            checksum_tree(repo, subid)
+            checksum_tree(repo, os.path.join(path, fname), subid)
         elif otype == 'commit':
-            checksum_repo(os.path.join(repo, fname), subid)
+            checksum_repo(os.path.join(repo, path, fname), subid)
         else:
             assert False
     p.wait()
@@ -100,7 +100,7 @@ def checksum_tree(repo, objid):
 
 def checksum_repo(repo, objid):
     treeid = checksum_object(repo, objid)
-    checksum_tree(repo, treeid)
+    checksum_tree(repo, '.', treeid)
 
 checksum_repo('.', opts.rev)
 

--- a/src/git-evtag.c
+++ b/src/git-evtag.c
@@ -258,7 +258,10 @@ checksum_tree_callback (const char *root,
     case GIT_OBJ_COMMIT:
       {
         git_submodule *submod = NULL;
-        tmp_r = git_submodule_lookup (&submod, twdata->repo, git_tree_entry_name (entry));
+        char *submodule_path = g_build_filename (root, git_tree_entry_name (entry), NULL);
+        tmp_r = git_submodule_lookup (&submod, twdata->repo, submodule_path);
+        g_free (submodule_path);
+
         if (!handle_libgit_ret (tmp_r, twdata->error))
           goto out;
 

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -143,8 +143,21 @@ setup_test_repository () {
     gitcommit_inctime -a -m 'Add libsub'
     git push
 
+    # Copy coolproject to create another version which has two submodules,
+    # one which is nested deeper in the repository.
+    cd ${test_tmpdir}
+    cp -r repos/coolproject repos/coolproject2
+    git clone file://${test_tmpdir}/repos/coolproject2
+    cd coolproject2
+    mkdir subprojects
+    git submodule add ../subproject subprojects/subproject
+    git add subprojects/subproject
+    gitcommit_inctime -a -m 'Add subprojects/subproject'
+    git push
+
     cd ${test_tmpdir}
     rm coolproject -rf
+    rm coolproject2 -rf
     rm subproject -rf
 
     cd $oldpwd


### PR DESCRIPTION
While top-level submodules (e.g. $GIT_DIR/mysubmodule) were working
fine, those in subdirectories (for example,
$GIT_DIR/subprojects/mysubmodule) were not, since the middle part of the
path (‘subprojects’) was being dropped during the checksum recursion.

Fixing this is especially important for any project using Meson-style
subprojects, which are conventionally all grouped in the ‘subprojects’
directory.

Signed-off-by: Philip Withnall <withnall@endlessm.com>