### PR TITLE
Fix distcheck, enable Github Actions workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,97 @@
+name: CI checks
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  check:
+    name: Build with Autotools and gcc, and test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out
+      uses: actions/checkout@v1
+    - name: Install build-dependencies
+      run: sudo ./packaging/builddeps.sh
+    - name: Create logs dir
+      run: mkdir test-logs
+    - name: autogen.sh
+      run: NOCONFIGURE=1 ./autogen.sh
+    - name: configure
+      run: |
+        mkdir _build
+        pushd _build
+        ../configure \
+          --enable-installed-tests \
+          --enable-man \
+          ${NULL+}
+        popd
+      env:
+        CFLAGS: >-
+          -O2
+          -Wp,-D_FORTIFY_SOURCE=2
+          -fsanitize=address
+          -fsanitize=undefined
+    - name: make
+      run: |
+        make -C _build -j $(getconf _NPROCESSORS_ONLN) V=1
+    - name: check
+      run: |
+        make -C _build -j $(getconf _NPROCESSORS_ONLN) check VERBOSE=1
+      env:
+        ASAN_OPTIONS: detect_leaks=0
+    - name: install
+      run: |
+        make -C _build install DESTDIR="$(pwd)/DESTDIR"
+        ( cd DESTDIR && find -ls )
+        sudo make -C _build install
+    - name: installed-tests
+      run: |
+        ginsttest-runner -L test-logs --tap git-evtag
+      env:
+        ASAN_OPTIONS: detect_leaks=0
+    - name: distcheck
+      run: |
+        make -C _build -j $(getconf _NPROCESSORS_ONLN) distcheck VERBOSE=1
+      env:
+        ASAN_OPTIONS: detect_leaks=0
+    - name: Collect test logs on failure
+      if: failure() || cancelled()
+      run: |
+        mv _build/test-suite/*.log test-logs/ || true
+        mv _build/tests/*.log test-logs/ || true
+    - name: Upload test logs
+      uses: actions/upload-artifact@v1
+      if: failure() || cancelled()
+      with:
+        name: test logs
+        path: test-logs
+
+  clang:
+    name: Build with clang
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out
+      uses: actions/checkout@v2
+    - name: Install build-dependencies
+      run: sudo ./packaging/builddeps.sh --clang
+    - name: autogen.sh
+      run: NOCONFIGURE=1 ./autogen.sh
+    # Do this one as an in-tree build to prove we can
+    - name: configure
+      run: |
+        ./configure \
+          --enable-installed-tests \
+          --enable-man \
+          ${NULL+}
+      env:
+        CC: clang
+        CFLAGS: >-
+          -O2
+          -Werror=unused-variable
+    - name: make
+      run: make -j $(getconf _NPROCESSORS_ONLN) V=1

--- a/packaging/builddeps.sh
+++ b/packaging/builddeps.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Copyright 2021 Simon McVittie
+# SPDX-License-Identifier: LGPL-2.0-or-later
+
+set -eux
+set -o pipefail
+
+usage() {
+    if [ "${1-2}" -ne 0 ]; then
+        exec >&2
+    fi
+    cat <<EOF
+Usage: see source code
+EOF
+    exit "${1-2}"
+}
+
+opt_clang=
+
+getopt_temp="help"
+getopt_temp="$getopt_temp,clang"
+
+getopt_temp="$(getopt -o '' --long "${getopt_temp}" -n "$0" -- "$@")"
+eval set -- "$getopt_temp"
+unset getopt_temp
+
+while true; do
+    case "$1" in
+        (--clang)
+            clang=yes
+            shift
+            ;;
+
+        (--help)
+            usage 0
+            # not reached
+            ;;
+
+        (--)
+            shift
+            break
+            ;;
+
+        (*)
+            echo 'Error parsing options' >&2
+            usage 2
+            ;;
+    esac
+done
+
+# No more arguments please
+for arg in "$@"; do
+    usage 2
+done
+
+if dpkg-vendor --derives-from Debian; then
+    apt-get -y update
+    apt-get -q -y install \
+        autoconf \
+        automake \
+        build-essential \
+        docbook-xml \
+        docbook-xsl \
+        git \
+        gnome-desktop-testing \
+        gnupg \
+        libgit2-glib-1.0-dev \
+        libtool \
+        meson \
+        pkg-config \
+        python3 \
+        xsltproc \
+        ${NULL+}
+
+    if [ -n "${opt_clang}" ]; then
+        apt-get -y install clang
+    fi
+
+    exit 0
+fi
+
+if command -v yum; then
+    yum -y install \
+        autoconf \
+        automake \
+        docbook-style-xsl \
+        gcc \
+        git \
+        gnome-desktop-testing \
+        gnupg2 \
+        libasan \
+        libtool \
+        libtsan \
+        libubsan \
+        libxslt \
+        make \
+        meson \
+        pkgconfig(libgit2-glib-1.0) \
+        redhat-rpm-config \
+        rsync \
+        ${NULL+}
+
+    if [ -n "${opt_clang}" ]; then
+        yum -y install clang
+    fi
+
+    exit 0
+fi
+
+echo "Unknown distribution" >&2
+exit 1
+
+# vim:set sw=4 sts=4 et:

--- a/rust/Makefile-inc.am
+++ b/rust/Makefile-inc.am
@@ -1,6 +1,12 @@
 if ENABLE_RUST
 bin_PROGRAMS += git-rustevtag
+git_rustevtag_SOURCES = \
+	rust/Cargo.toml \
+	rust/src/main.rs \
+	$(NULL)
 
-git-rustevtag: rust/src/main.rs rust/Cargo.toml
+git-rustevtag: $(git_rustevtag_SOURCES)
 	(cd rust && cargo build) && cp rust/target/debug/git-rustevtag .
 endif
+
+EXTRA_DIST += rust/rustfmt.toml

--- a/tests/Makefile-tests.am
+++ b/tests/Makefile-tests.am
@@ -22,6 +22,7 @@ AM_TESTS_ENVIRONMENT = \
 	$(NULL)
 LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) $(top_srcdir)/build-aux/tap-driver.sh
 LOG_COMPILER = $(srcdir)/tests/tap-test
+EXTRA_DIST += tests/tap-test
 
 TESTS = \
 	tests/test-basic.sh \
@@ -32,25 +33,26 @@ if BUILDOPT_INSTALL_TESTS
 insttestdir=$(pkglibexecdir)/installed-tests
 testfiles = test-basic \
 	$(NULL)
-insttest_SCRIPTS = $(addprefix tests/,$(testfiles:=.sh))
+dist_insttest_SCRIPTS = $(addprefix tests/,$(testfiles:=.sh))
 
 testmetadir = $(datadir)/installed-tests/$(PACKAGE)
 testmeta_DATA = $(testfiles:=.test)
 
-insttest_DATA = \
+dist_insttest_DATA = \
 	tests/libtest.sh \
 	$(NULL)
 
-insttest_SCRIPTS += src/git-evtag-compute-py
+dist_insttest_SCRIPTS += src/git-evtag-compute-py
+EXTRA_DIST += tests/git-evtag-compute-py
 
 gpginsttestdir = $(pkglibexecdir)/installed-tests/gpghome
-gpginsttest_DATA = tests/gpghome/secring.gpg \
+dist_gpginsttest_DATA = tests/gpghome/secring.gpg \
 	tests/gpghome/trustdb.gpg \
 	tests/gpghome/key1.asc \
 	tests/gpghome/key2.asc \
 	tests/gpghome/key3.asc
 gpginsttest_trusteddir = $(pkglibexecdir)/installed-tests/gpghome/trusted
-gpginsttest_trusted_DATA = tests/gpghome/trusted/pubring.gpg
+dist_gpginsttest_trusted_DATA = tests/gpghome/trusted/pubring.gpg
 
 install-gpg-data-hook:
 	ln -sf trusted/pubring.gpg $(DESTDIR)$(gpginsttestdir)/pubring.gpg 

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -33,6 +33,7 @@ export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
 # homedir in order to create lockfiles.  Work around
 # this by copying locally.
 cp -a ${SRCDIR}/gpghome ${test_tmpdir}
+chmod -R u+w ${test_tmpdir}/gpghome
 chmod 0700 ${test_tmpdir}/gpghome
 export GNUPGHOME=${test_tmpdir}/gpghome
 


### PR DESCRIPTION
* tests: Ensure files in the test temporary directory are writeable
    
    Otherwise we'll be unable to remove gpghome/trusted/pubring.gpg during
    distcheck, because distcheck operates from a read-only copy of the
    source tree.

* tests: Fix distcheck
    
    If we want `make dist` to work, then we need to add the test scripts
    and test data to the dist tarball.

* rust: Fix distcheck
    
    If we don't tell Automake what the sources for an executable are, it
    will assume that it needs to distribute `$(name-of-executable).c`
    in the dist tarball, which is not correct in this case.

* workflows: Add some CI checks
    
    Based on the workflows I contributed to bubblewrap, which in turn were
    loosely based on the ones in Flatpak.