### PR TITLE
build: Add a Meson build system

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -71,6 +71,44 @@ jobs:
         name: test logs
         path: test-logs
 
+  meson:
+    name: Build with Meson and gcc, and test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out
+      uses: actions/checkout@v1
+    - name: Install build-dependencies
+      run: sudo ./packaging/builddeps.sh
+    - name: Create logs dir
+      run: mkdir test-logs
+    - name: configure
+      run: |
+        meson setup -Dinstall_tests=true -Dman=enabled _build
+    - name: compile
+      run: |
+        meson compile -C _build -v
+    - name: test
+      run: |
+        meson test -C _build -v
+    - name: install
+      run: |
+        DESTDIR="$(pwd)/DESTDIR" meson install -C _build
+        ( cd DESTDIR && find -ls )
+        sudo meson install -C _build
+    - name: installed-tests
+      run: |
+        ginsttest-runner -L test-logs --tap git-evtag
+    - name: Collect test logs on failure
+      if: failure() || cancelled()
+      run: |
+        mv _build/meson-logs/* test-logs/ || true
+    - name: Upload test logs
+      uses: actions/upload-artifact@v1
+      if: failure() || cancelled()
+      with:
+        name: Meson logs
+        path: test-logs
+
   clang:
     name: Build with clang
     runs-on: ubuntu-latest

--- a/Makefile.am
+++ b/Makefile.am
@@ -25,6 +25,10 @@ AM_CPPFLAGS += -DDATADIR='"$(datadir)"' \
 	-DLOCALEDIR=\"$(datadir)/locale\"
 AM_CFLAGS += $(WARN_CFLAGS)
 
+EXTRA_DIST += meson.build
+EXTRA_DIST += meson_options.txt
+EXTRA_DIST += packaging/meson-compat-install-symlink.sh
+
 GITIGNOREFILES += build-aux/ m4/ gtk-doc.make config.h.in aclocal.m4
 GITIGNOREFILES += git-evtag-*.tar.*
 
@@ -39,3 +43,13 @@ $(srcdir)/.gitignore: src/Makefile-git-evtag.am
 $(srcdir)/.gitignore: man/Makefile-man.am
 $(srcdir)/.gitignore: rust/Makefile-inc.am
 $(srcdir)/.gitignore: tests/Makefile-tests.am
+
+distcheck-hook: distcheck-hook-meson
+distcheck-hook-meson:
+	set -e; if command -v meson > /dev/null; then \
+		cd $(distdir); \
+		meson setup _build/meson; \
+		meson compile -C _build/meson -v; \
+		meson test -C _build/meson -v; \
+		rm -fr _build/meson; \
+	fi

--- a/man/Makefile-man.am
+++ b/man/Makefile-man.am
@@ -45,3 +45,4 @@ CLEANFILES += \
 endif
 
 EXTRA_DIST += man/git-evtag.xml
+EXTRA_DIST += man/meson.build

--- a/man/Makefile-man.am
+++ b/man/Makefile-man.am
@@ -43,3 +43,5 @@ CLEANFILES += \
 	$(NULL)
 
 endif
+
+EXTRA_DIST += man/git-evtag.xml

--- a/man/meson.build
+++ b/man/meson.build
@@ -1,0 +1,41 @@
+# Copyright 2022 Simon McVittie
+# SPDX-License-Identifier: MIT
+
+manpages_xsl = 'http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl'
+xsltproc = find_program('xsltproc', required : get_option('man'))
+build_man_page = false
+
+if xsltproc.found()
+  if run_command([
+    xsltproc, '--nonet', manpages_xsl,
+  ], check : false).returncode() == 0
+    message('Docbook XSL found, man page enabled')
+    build_man_page = true
+  elif get_option('man').enabled()
+    error('Man page requested, but Docbook XSL stylesheets not found')
+  else
+    message('Docbook XSL not found, man page disabled automatically')
+  endif
+endif
+
+if build_man_page
+  custom_target(
+    'git-evtag.1',
+    output : 'git-evtag.1',
+    input : 'git-evtag.xml',
+    command : [
+      xsltproc,
+      '--nonet',
+      '--stringparam', 'man.output.quietly', '1',
+      '--stringparam', 'funcsynopsis.style', 'ansi',
+      '--stringparam', 'man.th.extra1.suppress', '1',
+      '--stringparam', 'man.authors.section.enabled', '0',
+      '--stringparam', 'man.copyright.section.enabled', '0',
+      '-o', '@OUTPUT@',
+      manpages_xsl,
+      '@INPUT@',
+    ],
+    install : true,
+    install_dir : get_option('mandir') / 'man1',
+  )
+endif

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,108 @@
+# Copyright 2022 Simon McVittie
+# SPDX-License-Identifier: MIT
+
+project(
+  'git-evtag',
+  'c',
+  version : '2016.1',
+  meson_version : '>=0.50.0',
+  default_options : [
+    'warning_level=2',
+  ],
+)
+
+cc = meson.get_compiler('c')
+add_project_arguments('-D_GNU_SOURCE', language : 'c')
+common_include_directories = include_directories('.')
+
+add_project_arguments(
+  cc.get_supported_arguments([
+    '-Werror=aggregate-return',
+    '-Werror=declaration-after-statement',
+    '-Werror=format-security',
+    '-Werror=format=2',
+    '-Werror=implicit-function-declaration',
+    '-Werror=init-self',
+    '-Werror=missing-include-dirs',
+    '-Werror=missing-prototypes',
+    '-Werror=pointer-arith',
+
+    '-Wstrict-prototypes',
+  ]),
+  language : 'c',
+)
+
+foreach no_warning : ['missing-field-initializers', 'unused-parameter']
+  add_project_arguments(
+    cc.get_supported_arguments([
+      '-Wno-' + no_warning,
+      '-Wno-error=' + no_warning,
+    ]),
+    language : 'c',
+  )
+endforeach
+
+# These can be replaced with meson.project_*_root() with a Meson 0.56
+# dependency
+project_build_root = meson.current_build_dir()
+project_source_root = meson.current_source_dir()
+
+glib_dep = dependency('gio-2.0', required : true)
+libgit_glib_dep = dependency('libgit2', required : true)
+
+cdata = configuration_data()
+cdata.set_quoted(
+  'DATADIR',
+  get_option('prefix') / get_option('datadir'),
+)
+cdata.set_quoted(
+  'LIBEXECDIR',
+  get_option('prefix') / get_option('libexecdir'),
+)
+cdata.set_quoted(
+  'LOCALEDIR',
+  get_option('prefix') / get_option('datadir') / 'locale',
+)
+cdata.set_quoted(
+  'PACKAGE_STRING',
+  '@0@ @1@'.format(meson.project_name(), meson.project_version()),
+)
+
+foreach function : ['git_libgit2_init']
+  if cc.has_function(
+    function,
+    dependencies : libgit_glib_dep,
+    prefix : '#include <git2.h>',
+  )
+    cdata.set('HAVE_' + function.to_upper().underscorify(), 1)
+  endif
+endforeach
+
+configure_file(
+  output : 'config.h',
+  configuration : cdata,
+)
+
+install_symlinks = []
+
+subdir('src')
+subdir('man')
+subdir('rust')
+subdir('tests')
+
+foreach symlink : install_symlinks
+  if meson.version().version_compare('>=0.61.0') and not symlink['pointing_to'].startswith('/')
+    install_symlink(
+      symlink['link_name'],
+      install_dir : symlink['install_dir'],
+      pointing_to : symlink['pointing_to'],
+    )
+  else
+    meson.add_install_script(
+      'packaging/meson-compat-install-symlink.sh',
+      symlink['link_name'],
+      symlink['install_dir'],
+      symlink['pointing_to'],
+    )
+  endif
+endforeach

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,22 @@
+# Copyright 2022 Simon McVittie
+# SPDX-License-Identifier: MIT
+
+option(
+  'install_tests',
+  type : 'boolean',
+  description : 'Install test programs',
+  value : false,
+)
+option(
+  'man',
+  type : 'feature',
+  description : 'Generate man pages',
+  value : 'auto',
+)
+# "Option name rust is reserved"
+option(
+  'build_rust_version',
+  type : 'feature',
+  description : 'Compile Rust version',
+  value : 'disabled',
+)

--- a/packaging/meson-compat-install-symlink.sh
+++ b/packaging/meson-compat-install-symlink.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Copyright 2022 Simon McVittie
+# SPDX-License-Identifier: MIT
+
+# Compatibility shim for installing symlinks with Meson < 0.61
+
+set -eu
+
+case "$2" in
+  (/*)
+    ln -fns "$3" "$DESTDIR/$2/$1"
+    ;;
+  (*)
+    ln -fns "$3" "$MESON_INSTALL_DESTDIR_PREFIX/$2/$1"
+    ;;
+esac

--- a/rust/Makefile-inc.am
+++ b/rust/Makefile-inc.am
@@ -6,7 +6,7 @@ git_rustevtag_SOURCES = \
 	$(NULL)
 
 git-rustevtag: $(git_rustevtag_SOURCES)
-	(cd rust && cargo build) && cp rust/target/debug/git-rustevtag .
+	(cd rust && cargo build) && cp rust/target/debug/git-evtag "$@"
 endif
 
 EXTRA_DIST += rust/rustfmt.toml

--- a/rust/Makefile-inc.am
+++ b/rust/Makefile-inc.am
@@ -9,4 +9,5 @@ git-rustevtag: $(git_rustevtag_SOURCES)
 	(cd rust && cargo build) && cp rust/target/debug/git-evtag "$@"
 endif
 
+EXTRA_DIST += rust/meson.build
 EXTRA_DIST += rust/rustfmt.toml

--- a/rust/meson.build
+++ b/rust/meson.build
@@ -1,0 +1,19 @@
+# Copyright 2022 Simon McVittie
+# SPDX-License-Identifier: MIT
+
+cargo = find_program('cargo', required : get_option('build_rust_version'))
+
+if cargo.found()
+  custom_target(
+    'git-rustevtag',
+    input : ['Cargo.toml', 'src/main.rs'],
+    output : 'git-rustevtag',
+    command : [
+      'sh', '-euc',
+      '"$1" build && cp target/debug/git-evtag "$2"',
+      'sh',
+      cargo,
+      '@OUTPUT0@',
+    ],
+  )
+endif

--- a/src/Makefile-git-evtag.am
+++ b/src/Makefile-git-evtag.am
@@ -24,3 +24,5 @@ git_evtag_CFLAGS = $(AM_CFLAGS) $(BUILDDEP_LIBGIT_GLIB_CFLAGS)  -I$(srcdir)/src
 git_evtag_LDADD = $(BUILDDEP_LIBGIT_GLIB_LIBS)
 
 GITIGNOREFILES += src/.dirstamp
+
+EXTRA_DIST += src/meson.build

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,10 @@
+# Copyright 2022 Simon McVittie
+# SPDX-License-Identifier: MIT
+
+executable(
+  'git-evtag',
+  ['git-evtag.c'],
+  include_directories : common_include_directories,
+  install : true,
+  dependencies : [glib_dep, libgit_glib_dep],
+)

--- a/tests/Makefile-tests.am
+++ b/tests/Makefile-tests.am
@@ -22,7 +22,11 @@ AM_TESTS_ENVIRONMENT = \
 	$(NULL)
 LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) $(top_srcdir)/build-aux/tap-driver.sh
 LOG_COMPILER = $(srcdir)/tests/tap-test
+EXTRA_DIST += tests/gpghome/meson.build
+EXTRA_DIST += tests/gpghome/trusted/meson.build
+EXTRA_DIST += tests/meson.build
 EXTRA_DIST += tests/tap-test
+EXTRA_DIST += tests/tap.test.in
 
 test_scripts = \
 	tests/test-basic.sh \

--- a/tests/gpghome/meson.build
+++ b/tests/gpghome/meson.build
@@ -1,0 +1,21 @@
+# Copyright 2022 Simon McVittie
+# SPDX-License-Identifier: MIT
+
+if get_option('install_tests')
+  install_data(
+    'key1.asc',
+    'key2.asc',
+    'key3.asc',
+    'secring.gpg',
+    'trustdb.gpg',
+    install_dir : insttestdir / 'gpghome',
+  )
+
+  install_symlinks += {
+    'link_name' : 'pubring.gpg',
+    'install_dir' : insttestdir / 'gpghome',
+    'pointing_to' : 'trusted/pubring.gpg',
+  }
+endif
+
+subdir('trusted')

--- a/tests/gpghome/trusted/meson.build
+++ b/tests/gpghome/trusted/meson.build
@@ -1,0 +1,9 @@
+# Copyright 2022 Simon McVittie
+# SPDX-License-Identifier: MIT
+
+if get_option('install_tests')
+  install_data(
+    'pubring.gpg',
+    install_dir : insttestdir / 'gpghome/trusted',
+  )
+endif

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -115,60 +115,60 @@ setup_test_repository () {
     cd ${test_tmpdir}
     mkdir coolproject
     cd coolproject
-    git init -b mybranch
-    gitcommit_reset_time
+    git init -b mybranch >&2
+    gitcommit_reset_time >&2
     echo 'So cool!' > README.md
-    git add .
-    gitcommit_inctime -a -m 'Initial commit'
+    git add . >&2
+    gitcommit_inctime -a -m 'Initial commit' >&2
     mkdir src
     echo 'printf("hello world")' > src/cool.c
-    git add .
-    gitcommit_inctime -a -m 'Add C source'
+    git add . >&2
+    gitcommit_inctime -a -m 'Add C source' >&2
 
     cd ${test_tmpdir}
     mkdir -p repos/coolproject
-    cd repos/coolproject && git init --bare -b mybranch
+    cd repos/coolproject && git init --bare -b mybranch >&2
     cd ${test_tmpdir}/coolproject
-    git remote add origin file://${test_tmpdir}/repos/coolproject
-    git push --set-upstream origin mybranch
+    git remote add origin file://${test_tmpdir}/repos/coolproject >&2
+    git push --set-upstream origin mybranch >&2
 
     cd ${test_tmpdir}
     mkdir subproject
     cd subproject
-    git init -b mybranch
+    git init -b mybranch >&2
     echo 'this is libsub.c' > libsub.c
     echo 'An example submodule' > README.md
-    git add .
-    gitcommit_inctime -a -m 'init'
+    git add . >&2
+    gitcommit_inctime -a -m 'init' >&2
     mkdir src
     mv libsub.c src
     echo 'an update to libsub.c, now in src/' > src/libsub.c
-    gitcommit_inctime -a -m 'an update'
+    gitcommit_inctime -a -m 'an update' >&2
     cd ${test_tmpdir}
     mkdir -p repos/subproject
-    cd repos/subproject && git init --bare -b mybranch
+    cd repos/subproject && git init --bare -b mybranch >&2
     cd ${test_tmpdir}/subproject
-    git remote add origin file://${test_tmpdir}/repos/subproject
-    git push --set-upstream origin mybranch
+    git remote add origin file://${test_tmpdir}/repos/subproject >&2
+    git push --set-upstream origin mybranch >&2
 
     cd ${test_tmpdir}/coolproject
-    trusted_git_submodule add ../subproject subproject
-    git add subproject
+    trusted_git_submodule add ../subproject subproject >&2
+    git add subproject >&2
     echo '#include subproject/src/libsub.c' >> src/cool.c
-    gitcommit_inctime -a -m 'Add libsub'
-    git push origin mybranch
+    gitcommit_inctime -a -m 'Add libsub' >&2
+    git push origin mybranch >&2
 
     # Copy coolproject to create another version which has two submodules,
     # one which is nested deeper in the repository.
     cd ${test_tmpdir}
     cp -r repos/coolproject repos/coolproject2
-    git clone file://${test_tmpdir}/repos/coolproject2
+    git clone file://${test_tmpdir}/repos/coolproject2 >&2
     cd coolproject2
     mkdir subprojects
-    trusted_git_submodule add ../subproject subprojects/subproject
-    git add subprojects/subproject
-    gitcommit_inctime -a -m 'Add subprojects/subproject'
-    git push origin mybranch
+    trusted_git_submodule add ../subproject subprojects/subproject >&2
+    git add subprojects/subproject >&2
+    gitcommit_inctime -a -m 'Add subprojects/subproject' >&2
+    git push origin mybranch >&2
 
     cd ${test_tmpdir}
     rm coolproject -rf

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,52 @@
+# Copyright 2022 Simon McVittie
+# SPDX-License-Identifier: MIT
+
+insttestdir = get_option('libexecdir') / 'installed-tests'
+insttestmetadir = get_option('datadir') / 'installed-tests' / meson.project_name()
+
+test_scripts = [
+  'test-basic.sh',
+]
+
+test_env = environment()
+test_env.prepend('PATH', project_build_root / 'src')
+test_env.set('G_TEST_BUILDDIR', project_build_root)
+test_env.set('G_TEST_SRCDIR', project_source_root)
+
+foreach test_script : test_scripts
+  test(
+    test_script,
+    files('tap-test'),
+    args : [files(test_script)],
+    env : test_env,
+    protocol : 'tap',
+  )
+
+  if get_option('install_tests')
+    configure_file(
+      input : 'tap.test.in',
+      output : test_script + '.test',
+      configuration : {
+        'basename' : test_script,
+        'insttestdir' : get_option('prefix') / insttestdir,
+      },
+      install_dir : insttestmetadir,
+    )
+  endif
+endforeach
+
+if get_option('install_tests')
+  install_data(
+    'libtest.sh',
+    install_dir : insttestdir,
+  )
+  install_data(
+    test_scripts + [
+      project_source_root / 'src/git-evtag-compute-py',
+    ],
+    install_dir : insttestdir,
+    install_mode : 'rwxr-xr-x',
+  )
+endif
+
+subdir('gpghome')

--- a/tests/tap.test.in
+++ b/tests/tap.test.in
@@ -1,0 +1,7 @@
+# Copyright 2022 Simon McVittie
+# SPDX-License-Identifier: MIT
+
+[Test]
+Type=session
+Exec=@insttestdir@/@basename@
+Output=TAP

--- a/tests/test-basic.sh
+++ b/tests/test-basic.sh
@@ -28,20 +28,20 @@ cd ${test_tmpdir}
 create_editor_script 'Release 2015.1'
 echo "ok setup"
 
-git clone repos/coolproject
+git clone repos/coolproject >&2
 cd coolproject
-trusted_git_submodule update --init
-with_editor_script git evtag sign -u 472CDAFA v2015.1
+trusted_git_submodule update --init >&2
+with_editor_script git evtag sign -u 472CDAFA v2015.1 >&2
 git show refs/tags/v2015.1 > tag.txt
 sed -e 's/^/#tag.txt /' < tag.txt
 ${SRCDIR}/git-evtag-compute-py HEAD > tag-py.txt
 sed -e 's/^/#tag-py.txt /' < tag-py.txt
 TAG='Git-EVTag-v0-SHA512: 58e9834248c054f844f00148a030876f77eb85daa3caa15a20f3061f181403bae7b7e497fca199d25833b984c60f3202b16ebe0ed3a36e6b82f33618d75c569d'
 assert_file_has_content tag.txt "${TAG}"
-with_editor_script git evtag verify v2015.1 | tee verify.out
+with_editor_script git evtag verify v2015.1 | tee verify.out >&2
 assert_file_has_content verify.out "Successfully verified: ${TAG}"
 # Also test subdirectory
-(cd src && with_editor_script git evtag verify v2015.1 | tee ../verify2.out)
+(cd src && with_editor_script git evtag verify v2015.1 | tee ../verify2.out) >&2
 assert_file_has_content verify2.out "Successfully verified: ${TAG}"
 assert_file_has_content tag-py.txt "${TAG}"
 
@@ -51,30 +51,30 @@ echo "ok tag + verify"
 
 cd ${test_tmpdir}
 rm coolproject -rf
-git clone repos/coolproject
+git clone repos/coolproject >&2
 cd coolproject
-trusted_git_submodule update --init
+trusted_git_submodule update --init >&2
 echo 'super cool' > src/cool.c
-if with_editor_script git evtag sign -u 472CDAFA v2015.1 2>err.txt; then
+if with_editor_script git evtag sign -u 472CDAFA v2015.1 >&2 2>err.txt; then
     assert_not_reached "expected failure due to dirty tree"
 fi
 assert_file_has_content err.txt 'Attempting to tag or verify dirty tree'
-git checkout src/cool.c
+git checkout src/cool.c >&2
 # But untracked files are ok
 touch unknownfile
-with_editor_script git evtag sign -u 472CDAFA v2015.1
-git evtag verify v2015.1
+with_editor_script git evtag sign -u 472CDAFA v2015.1 >&2
+git evtag verify v2015.1 >&2
 echo 'ok no tag on dirty tree'
 
 
 cd ${test_tmpdir}
 rm coolproject -rf
-git clone repos/coolproject
+git clone repos/coolproject >&2
 cd coolproject
-trusted_git_submodule update --init
-with_editor_script git evtag sign -u 472CDAFA v2015.1
-git checkout -q HEAD^
-if git evtag verify v2015.1 2>err.txt; then
+trusted_git_submodule update --init >&2
+with_editor_script git evtag sign -u 472CDAFA v2015.1 >&2
+git checkout -q HEAD^ >&2
+if git evtag verify v2015.1 >&2 2>err.txt; then
     assert_not_reached 'Expected failure due to non HEAD'
 fi
 assert_file_has_content err.txt "Target.*is not HEAD"
@@ -82,15 +82,15 @@ echo 'ok no tag verify on non-HEAD'
 
 cd ${test_tmpdir}
 rm coolproject -rf
-git clone repos/coolproject
+git clone repos/coolproject >&2
 cd coolproject
-trusted_git_submodule update --init
-with_editor_script git evtag sign --with-legacy-archive-tag -u 472CDAFA v2015.1
+trusted_git_submodule update --init >&2
+with_editor_script git evtag sign --with-legacy-archive-tag -u 472CDAFA v2015.1 >&2
 git show refs/tags/v2015.1 > tag.txt
 assert_file_has_content tag.txt 'ExtendedVerify-SHA256-archive-tar: 83991ee23a027d97ad1e06432ad87c6685e02eac38706e7fbfe6e5e781939dab'
 gitversion=$(git --version)
 assert_file_has_content tag.txt "ExtendedVerify-git-version: ${gitversion}"
-with_editor_script git evtag verify v2015.1 | tee verify.out
+with_editor_script git evtag verify v2015.1 | tee verify.out >&2
 assert_file_has_content verify.out 'Successfully verified: Git-EVTag-v0-SHA512: 58e9834248c054f844f00148a030876f77eb85daa3caa15a20f3061f181403bae7b7e497fca199d25833b984c60f3202b16ebe0ed3a36e6b82f33618d75c569d'
 rm -f tag.txt
 rm -f verify.out
@@ -98,10 +98,10 @@ echo "ok tag + verify legacy"
 
 cd ${test_tmpdir}
 rm coolproject -rf
-git clone repos/coolproject
+git clone repos/coolproject >&2
 cd coolproject
-trusted_git_submodule update --init
-with_editor_script git evtag sign --no-signature v2015.1
+trusted_git_submodule update --init >&2
+with_editor_script git evtag sign --no-signature v2015.1 >&2
 git show refs/tags/v2015.1 > tag.txt
 assert_file_has_content tag.txt 'Git-EVTag-v0-SHA512: 58e9834248c054f844f00148a030876f77eb85daa3caa15a20f3061f181403bae7b7e497fca199d25833b984c60f3202b16ebe0ed3a36e6b82f33618d75c569d'
 assert_not_file_has_content tag.txt '-----BEGIN PGP SIGNATURE-----'
@@ -109,24 +109,24 @@ if git evtag verify v2015.1 2>err.txt; then
     assert_not_reached 'Expected failure due to no GPG signature'
 fi
 assert_file_has_content err.txt "no signature found"
-git evtag verify --no-signature v2015.1
+git evtag verify --no-signature v2015.1 >&2
 rm -f tag.txt
 rm -f verify.out
 echo "ok checksum-only tag + verify"
 
 cd ${test_tmpdir}
 rm coolproject -rf
-git clone repos/coolproject2
+git clone repos/coolproject2 >&2
 cd coolproject2
-trusted_git_submodule update --init
-with_editor_script git evtag sign -u 472CDAFA v2015.1
+trusted_git_submodule update --init >&2
+with_editor_script git evtag sign -u 472CDAFA v2015.1 >&2
 git show refs/tags/v2015.1 > tag.txt
 TAG='Git-EVTag-v0-SHA512: 8ef922041663821b8208d6e1037adbd51e0b19cc4dd3314436b3078bdae4073a616e6e289891fa5ad9f798630962a33350f6035fffec6ca3c499bc01f07c3d0a'
 assert_file_has_content tag.txt "${TAG}"
-with_editor_script git evtag verify v2015.1 | tee verify.out
+with_editor_script git evtag verify v2015.1 | tee verify.out >&2
 assert_file_has_content verify.out "Successfully verified: ${TAG}"
 # Also test subdirectory
-(cd src && with_editor_script git evtag verify v2015.1 | tee ../verify2.out)
+(cd src && with_editor_script git evtag verify v2015.1 | tee ../verify2.out) >&2
 assert_file_has_content verify2.out "Successfully verified: ${TAG}"
 ${SRCDIR}/git-evtag-compute-py HEAD > tag-py.txt
 assert_file_has_content tag-py.txt "${TAG}"


### PR DESCRIPTION
* man: Include source code for the man page in dist tarballs

* rust: Fix build of git-rustevtag
    
    It's now built as git-evtag by the Cargo build system, so we need to
    rename it as part of copying it.

* tests: Be more strict about producing TAP output
    
    Autotools' TAP parser ignores unknown content on stdout, but Meson is
    much more strict and considers unknown content to be an error. Redirect
    commands' stdout to stderr if they can produce arbitrary unstructured
    diagnostics on stdout.

* build: Add a Meson build system