### PR TITLE
tests: Fix installation directory for "as-installed" tests under Meson

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,7 +1,7 @@
 # Copyright 2022 Simon McVittie
 # SPDX-License-Identifier: MIT
 
-insttestdir = get_option('libexecdir') / 'installed-tests'
+insttestdir = get_option('libexecdir') / 'installed-tests' / meson.project_name()
 insttestmetadir = get_option('datadir') / 'installed-tests' / meson.project_name()
 
 test_scripts = [


### PR DESCRIPTION
The convention for "as-installed" tests is that they are in a package-specific subdirectory of /usr/libexec/installed-tests, rather than directly inside /usr/libexec/installed-tests.

The Autotools build used an installed-tests subdirectory of the package-specific subdirectory of /usr/libexec, but this is unconventional, so take the opportunity to behave more like other packages.

Fixes: f6e1453f "build: Add a Meson build system"